### PR TITLE
Correct date format for vendor refresh

### DIFF
--- a/Server/Utils/refreshData.js
+++ b/Server/Utils/refreshData.js
@@ -24,12 +24,12 @@ async function refreshVendorData() {
       console.log("Manifest isn't outdated at the moment");
     }
     /*   await tokenRefreshRequest(); */
-    const newDate = new Date();
+    const currentDate = new Date();
     const config = await readConfig();
     const {
       Api: { vendorRefreshDate },
     } = config;
-    if (newDate >= new Date(vendorRefreshDate)) {
+    if (currentDate >= new Date(vendorRefreshDate)) {
       console.log("Vendor's inventory refresh date is expired");
       await tokenRefreshRequest();
       await vendorRequest();

--- a/Server/Utils/refreshData.js
+++ b/Server/Utils/refreshData.js
@@ -29,7 +29,7 @@ async function refreshVendorData() {
     const {
       Api: { vendorRefreshDate },
     } = config;
-    if (newDate >= vendorRefreshDate) {
+    if (newDate >= new Date(vendorRefreshDate)) {
       console.log("Vendor's inventory refresh date is expired");
       await tokenRefreshRequest();
       await vendorRequest();


### PR DESCRIPTION
Vendor refresh date(form Bungie's api) has a slightly different format than the one that javascript Date has.

I put the vendor refresh date into the Date constructor

